### PR TITLE
Adds require URI to faraday connection

### DIFF
--- a/lib/scorm_engine/faraday/connection.rb
+++ b/lib/scorm_engine/faraday/connection.rb
@@ -1,5 +1,6 @@
 require "faraday"
 require "faraday_middleware"
+require "uri"
 
 module ScormEngine
   module Faraday


### PR DESCRIPTION
#### JIRA

#### Changes

- Adds `require 'uri'` to the Faraday::Connection module after getting `/home/docker/.gem/ruby/2.7.0/gems/scorm_engine-0.9.0/lib/scorm_engine/faraday/connection.rb:9:in `base_uri': undefined method `URI' for #<ScormEngine::Client:0x00007f6d40d049b8> (NoMethodError)`

#### Checklist
- [ ] Feature Flag Required
- [ ] Bug

#### Test plan

- [ ] Walk-through
- [ ] Peer review
- [ ] Inspection
  - Detailed steps and prerequisites for validating the change:
    - <!-- Replace this with the bullet points about the steps how to execute the test -->

#### Risk Analysis - the risk of change is evaluated

- [ ] Low - Majority of the changes are low risk which doesn’t require extra testing, only code review by 1 reviewer
    - [ ] 1 reviewer
- [ ] Medium - Some portion of changes are medium risk which need peer testing and review by 2 reviewers
    - [ ] 2 reviewers
    - [ ] peer testing
- [ ] High - A very few breaking changes are high risk and need very throughout testing and review and also coordinated release process.
    - [ ] 2 reviewers
    - [ ] peer testing
    - [ ] coordinated release
