### PR TITLE
BRD-20938 Migrate ScormEngine to API v2 default with v23 compatibility

### DIFF
--- a/lib/scorm_engine/client.rb
+++ b/lib/scorm_engine/client.rb
@@ -12,6 +12,11 @@ module ScormEngine
 
     def initialize(tenant:)
       @tenant = tenant
+      @api_version = 2  # Default to API v2
+    end
+
+    def current_api_version
+      @api_version || 2
     end
   end
 end

--- a/lib/scorm_engine/faraday/connection.rb
+++ b/lib/scorm_engine/faraday/connection.rb
@@ -5,7 +5,7 @@ module ScormEngine
   module Faraday
     module Connection
 
-      def base_uri(version: 1)
+      def base_uri(version: 2)  # Default to v2
         uri = URI("")
         uri.scheme = ScormEngine.configuration.protocol
         uri.host = ScormEngine.configuration.host
@@ -21,7 +21,7 @@ module ScormEngine
 
       private
 
-      def connection(version: 1)
+      def connection(version: 2)  # Default to v2
         @connection ||= ::Faraday.new(url: base_uri(version: version).to_s) do |faraday|
           faraday.headers["User-Agent"] = "ScormEngine Ruby Gem #{ScormEngine::VERSION}"
 

--- a/lib/scorm_engine/faraday/request.rb
+++ b/lib/scorm_engine/faraday/request.rb
@@ -23,14 +23,24 @@ module ScormEngine
 
         yield
       ensure
+        @api_version = nil  # Reset to default
+      end
+
+      def api_v1
         @api_version = 1
+
+        yield
+      ensure
+        @api_version = nil  # Reset to default
       end
 
       private
 
       def request(method, path, options, body = nil)
-        connection(version: @api_version).send(method) do |request|
-          if @api_version == 2
+        api_version = @api_version || current_api_version
+        
+        connection(version: api_version).send(method) do |request|
+          if api_version == 2
             request.headers["engineTenantName"] = tenant unless @without_tenant
           else
             # "more" pagination urls are fully or relatively qualified

--- a/lib/scorm_engine/response.rb
+++ b/lib/scorm_engine/response.rb
@@ -22,5 +22,18 @@ module ScormEngine
     def message
       raw_response.body["message"] if raw_response.body.is_a?(Hash)
     end
+
+    def detailed_error_info
+      return "Success" if success?
+      
+      error_info = {
+        status: status,
+        message: message,
+        body: raw_response.body,
+        headers: raw_response.headers.to_hash
+      }
+      
+      error_info.inspect
+    end
   end
 end

--- a/lib/scorm_engine/version.rb
+++ b/lib/scorm_engine/version.rb
@@ -1,3 +1,3 @@
 module ScormEngine
-  VERSION = "0.9.0".freeze
+  VERSION = "0.10.0".freeze
 end


### PR DESCRIPTION
#### JIRA
https://getbridge.atlassian.net/browse/BRD-20938

#### Changes

- Bumped gem version from `0.9.0` to `0.10.0`
- Set `@api_version = 2` as default in initialiser (makes API v2 the default)
- Added conditional logic for `courseName` parameter based on API version
- Fixed response handling from `response.body` to `response.raw_response.body`

#### Checklist
- [ ] Feature Flag Required
- [ ] Bug

#### Test plan

- [ ] Walk-through
- [ ] Peer review
- [ ] Inspection
  - Detailed steps and prerequisites for validating the change:
    - <!-- Replace this with the bullet points about the steps how to execute the test -->

#### Risk Analysis - the risk of change is evaluated

- [ ] Low - Majority of the changes are low risk which doesn’t require extra testing, only code review by 1 reviewer
    - [ ] 1 reviewer
- [ ] Medium - Some portion of changes are medium risk which need peer testing and review by 2 reviewers
    - [ ] 2 reviewers
    - [ ] peer testing
- [ ] High - A very few breaking changes are high risk and need very throughout testing and review and also coordinated release process.
    - [ ] 2 reviewers
    - [ ] peer testing
    - [ ] coordinated release
